### PR TITLE
Bug fix for duplicate groups in _POST

### DIFF
--- a/autoassignusergroup/AutoAssignUserGroupPlugin.php
+++ b/autoassignusergroup/AutoAssignUserGroupPlugin.php
@@ -23,7 +23,7 @@ class AutoAssignUserGroupPlugin extends BasePlugin
 							$_POST['groups'] = $targetGroups;
 						} else {
 							// Merge in the user group ID with any existing ones.
-							$_POST['groups'] = array_merge($_POST['groups'], $targetGroups);
+							$_POST['groups'] = array_unique(array_merge($_POST['groups'], $targetGroups));
 						}
 					}
 				}
@@ -48,7 +48,7 @@ class AutoAssignUserGroupPlugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '1.1.0';
+		return '1.1.1';
 	}
 
 	public function getSchemaVersion()


### PR DESCRIPTION
If a user who has permission to assign a new user to user groups selected any of the groups chosen in the plugin’s settings, you end up with multiple array values of the same group which threw an error. This solves that by making sure the values are unique.